### PR TITLE
Update build configuration to use Java 17

### DIFF
--- a/DynamoDBLocal/pom.xml
+++ b/DynamoDBLocal/pom.xml
@@ -14,8 +14,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>11</source>
-                    <target>11</target>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ DynamoDB Local is a downloadable version of DynamoDB that enables you to develop
 This project showcases multiple approaches to set up and use DynamoDB Local, including downloading JAR files, running it as a Docker image, and using it as a Maven dependency.
 
 ## Prerequisites
-- Java Development Kit (JDK) 11 or later installed on your system
+- Java Development Kit (JDK) 17 or later installed on your system
 - Apache Maven installed on your system
 - Docker installed (if running DynamoDB Local as a Docker image)
 


### PR DESCRIPTION
**Issue #26**

**Description of changes:**

Since DynamoDBLocal 3.0.0 depends on Java 17, I updated using Java version to 17 from 11.
I've confirmed that the compile is working.

```bash
vscode ➜ /workspaces/amazon-dynamodb-local-samples/DynamoDBLocal (issue-26) $ mvn clean package
[INFO] Scanning for projects...
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for aws.example:DynamoDBLocal:jar:1.0-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ line 13, column 21
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
[INFO] 
[INFO] ---------------------< aws.example:DynamoDBLocal >----------------------
[INFO] Building DynamoDBLocal 1.0-SNAPSHOT
[INFO]   from pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- clean:3.2.0:clean (default-clean) @ DynamoDBLocal ---
[INFO] Deleting /workspaces/amazon-dynamodb-local-samples/DynamoDBLocal/target
[INFO] 
[INFO] --- resources:3.3.1:resources (default-resources) @ DynamoDBLocal ---
[WARNING] Using platform encoding (UTF-8 actually) to copy filtered resources, i.e. build is platform dependent!
[INFO] skip non existing resourceDirectory /workspaces/amazon-dynamodb-local-samples/DynamoDBLocal/src/main/resources
[INFO] 
[INFO] --- compiler:3.13.0:compile (default-compile) @ DynamoDBLocal ---
[INFO] Recompiling the module because of changed source code.
[WARNING] File encoding has not been set, using platform encoding UTF-8, i.e. build is platform dependent!
[INFO] Compiling 1 source file with javac [debug target 17] to target/classes
[INFO] 
[INFO] --- resources:3.3.1:testResources (default-testResources) @ DynamoDBLocal ---
[WARNING] Using platform encoding (UTF-8 actually) to copy filtered resources, i.e. build is platform dependent!
[INFO] skip non existing resourceDirectory /workspaces/amazon-dynamodb-local-samples/DynamoDBLocal/src/test/resources
[INFO] 
[INFO] --- compiler:3.13.0:testCompile (default-testCompile) @ DynamoDBLocal ---
[INFO] No sources to compile
[INFO] 
[INFO] --- surefire:3.2.5:test (default-test) @ DynamoDBLocal ---
[INFO] No tests to run.
[INFO] 
[INFO] --- jar:3.4.1:jar (default-jar) @ DynamoDBLocal ---
[INFO] Building jar: /workspaces/amazon-dynamodb-local-samples/DynamoDBLocal/target/DynamoDBLocal-1.0-SNAPSHOT.jar
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  2.385 s
[INFO] Finished at: 2025-08-02T08:19:32Z
[INFO] ------------------------------------------------------------------------
vscode ➜ /workspaces/amazon-dynamodb-local-samples/DynamoDBLocal (issue-26) $ 
```


